### PR TITLE
Fix: Missed sessions starts are now properly handled

### DIFF
--- a/Routines/TCPRXRoutine.go
+++ b/Routines/TCPRXRoutine.go
@@ -100,7 +100,7 @@ func HandleTCPReceivals(configJson map[string]interface{}, loggingChannel chan m
 			// 	" newSequence "+fmt.Sprint(newSequence)+
 			// 	" LastInSequence "+fmt.Sprint(LastInSequence))
 
-			if newSequence {
+			if newSequence && sessionContinuous {
 				// Lets start a new receipt sequence
 				JSONStartIndex := GetJSONStartIndex()
 
@@ -125,6 +125,13 @@ func HandleTCPReceivals(configJson map[string]interface{}, loggingChannel chan m
 			} else {
 				// There was some error so lets reset
 				JSONByteArray = nil
+
+				// The reset all states
+				previousSessionNumber = uint32(0)
+				previousSequenceNumber = uint32(0)
+				sessionContinuous = false
+				newSequence = false
+				LastInSequence = false
 
 				loggingChannel <- CreateLogMessage(zerolog.ErrorLevel, "Missed bytes, resetting")
 			}
@@ -185,6 +192,7 @@ func CheckSessionContinuity(transmissionState byte, sessionNumber uint32, sequen
 
 	// Now we check for continuity
 	if StartSequence {
+		// If it is the first sequence in a session
 		sessionContinuous = true
 		newSequence = true
 	} else if StartSequence || (SameSession && !LastInSequence && SequenceContinuous) {


### PR DESCRIPTION
to close #19 

If a sequence was missed in a session, the bytes would still be accumulated. This would cause an unmarshalling error when converting to json.

The fix now resets all session states so that bytes from a discontinuous session are discarded until a new session begins