### PR TITLE
38 feat add support for queue size reporting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 *.exe
 *.txt
 *.bak
+Go_TCP_Websocket_Adapter

--- a/Config.json
+++ b/Config.json
@@ -8,10 +8,6 @@
         "Port": "10010"
     },
     "WebSocketTxConfig": {
-        "Port": "10100",
-        "RegisteredChunks": [
-            "TimeChunk",
-            "FFTMagnitudeChunk"
-        ]
+        "Port": "10100"
     }
 }

--- a/Config.json
+++ b/Config.json
@@ -7,7 +7,10 @@
     "TCPRxConfig": {
         "Port": "10010"
     },
-    "WebSocketTxConfig": {
+    "WebSocketReportingTxConfig": {
         "Port": "10100"
+    },
+    "WebSocketDataTxConfig": {
+        "Port": "10101"
     }
-}
+}   

--- a/Config.json
+++ b/Config.json
@@ -8,9 +8,9 @@
         "Port": "10010"
     },
     "WebSocketReportingTxConfig": {
-        "Port": "10100"
+        "Port": "10101"
     },
     "WebSocketDataTxConfig": {
-        "Port": "10101"
+        "Port": "10100"
     }
 }   

--- a/Routines/ChunkRouter.go
+++ b/Routines/ChunkRouter.go
@@ -2,10 +2,10 @@ package Routines
 
 import (
 	"sync"
-	"time"
 	"github.com/gin-gonic/gin"
 	"github.com/rs/zerolog"
 	"github.com/gorilla/websocket"
+	"time"
 )
 
 var upgrader = websocket.Upgrader{

--- a/Routines/ChunkRouter.go
+++ b/Routines/ChunkRouter.go
@@ -8,6 +8,11 @@ import (
 	"github.com/gorilla/websocket"
 )
 
+var upgrader = websocket.Upgrader{
+	ReadBufferSize:  1024,
+	WriteBufferSize: 1024,
+}
+
 ///
 ///			ROUTINE SAFE MAP FUNCTIONS
 ///

--- a/Routines/ChunkRouter.go
+++ b/Routines/ChunkRouter.go
@@ -107,28 +107,11 @@ func (s *ChunkTypeToChannelMap)RegisterChunkOnWebSocket(loggingChannel chan map[
 	 router.GET("/DataTypes/"+chunkTypeString, func(c *gin.Context) {
 		// Upgrade the HTTP request into a websocket
 		WebSocketConnection, _ := upgrader.Upgrade(c.Writer, c.Request, nil)
-
 		defer WebSocketConnection.Close()
 
-		currentTime := time.Now()
-		lastTime := currentTime
-
-		// Then start up
-		var dataString, _ = s.GetChannelData(chunkTypeString)
-
-		WebSocketConnection.WriteMessage(websocket.TextMessage, []byte(dataString))
 		for {
-
-			currentTime = time.Now()
-			timeDiff := currentTime.Sub(lastTime)
-
 			var dataString, _ = s.GetChannelData(chunkTypeString)
-
-			// Rate limiting
-			if timeDiff > (time.Millisecond * 1) {
-				WebSocketConnection.WriteMessage(websocket.TextMessage, []byte(dataString))
-				lastTime = currentTime
-			}
+			WebSocketConnection.WriteMessage(websocket.TextMessage, []byte(dataString))
 		}
 	})
 }

--- a/Routines/ChunkRouter.go
+++ b/Routines/ChunkRouter.go
@@ -23,28 +23,43 @@ Each string corresponds to channel to send a chunk type to a
 routine that shall handle that chunk
 */
 type ChunkTypeToChannelMap struct {
-	mu                  sync.Mutex               // Mutex to protect access to the map
-	chunkTypeRoutingMap map[string](chan string) // Map of chunk type string and channel key value pairs
-	RoutineWaitGroup	sync.WaitGroup	
+	loggingOutputChannel 	chan map[zerolog.Level]string	// Channel to stream loggin messages
+	chunkTypeRoutingMap 	map[string](chan string) 		// Map of chunk type string and channel key value pairs
+	mu                  	sync.Mutex               		// Mutex to protect access to the map
+	routineWaitGroup		sync.WaitGroup
 }
 
+func NewChunkTypeToChannelMap(loggingOutputChannel 	chan map[zerolog.Level]string) *ChunkTypeToChannelMap {
+    p := new(ChunkTypeToChannelMap)
+    p.loggingOutputChannel = loggingOutputChannel
+    return p
+}
 /*
 Data string will be routed in the map given that chunk type key exists
 */
-func (s *ChunkTypeToChannelMap) SendChunkToWebSocket(loggingChannel chan map[zerolog.Level]string, chunkTypeKey string, data string, router *gin.Engine) bool {
+func (s *ChunkTypeToChannelMap) SendChunkToWebSocket(loggingChannel chan map[zerolog.Level]string, chunkTypeKey string, data string, router *gin.Engine) {
 
 	// We first check if the channel exists
 	// And wait to try get it
 	chunkRoutingChannel, channelExists := s.TryGetChannel(chunkTypeKey)
 	if channelExists {
-		// and pass the data if it does
+		// and try pass the data if it does if there is space in the queue
+		if len(chunkRoutingChannel) >= cap(chunkRoutingChannel) {
+			
+			// Note: One should see issues in the status messages. It may be useful to log this but the current
+			// Implementation does not gaurentee that the UI will service all queues which will lead most of them
+			// To be overloaded a lot of the time as only the loaded page will service a particular websocket
+
+			//loggingChannel <- CreateLogMessage(zerolog.WarnLevel, "ChunkType - "+chunkTypeKey+" - Routing queue overflowwing")
+			return
+		}
 		chunkRoutingChannel <- data
-		return channelExists
+
 	} else {
-		// or drop data and return false
-		// operate on the router itself
+		// If it does not set up a weboscket connection
+		// To manage connections for this chunk type
 		s.RegisterChunkOnWebSocket(loggingChannel, chunkTypeKey, router)
-		return channelExists
+		loggingChannel <- CreateLogMessage(zerolog.WarnLevel, "ChunkType - "+chunkTypeKey+" - registered for routing")
 	}
 }
 
@@ -73,6 +88,7 @@ func (s *ChunkTypeToChannelMap) TryGetChannel(chunkType string) (extractedChanne
 	for {
 		var lockAcquired = make(chan struct{}, 1)
 
+		// Spin this lambda up and try get the channel
 		go func() {
 			s.mu.Lock()
 			extractedChannel, exists = s.chunkTypeRoutingMap[chunkType]
@@ -80,13 +96,14 @@ func (s *ChunkTypeToChannelMap) TryGetChannel(chunkType string) (extractedChanne
 			defer close(lockAcquired)
 		}()
 
+		// Wait here until lock aquired channel is closed
 		select {
 		case <-lockAcquired:
 			// Lock was acquired
 			return extractedChannel, exists
 		case <-time.After(1 * time.Millisecond):
 			// Lock was not acquired, sleep and retry
-			time.Sleep(1 * time.Millisecond) // Sleep for 500 milliseconds, you can adjust the duration as needed.
+			time.Sleep(1 * time.Millisecond)
 		}
 	}
 }
@@ -118,19 +135,23 @@ func (s *ChunkTypeToChannelMap)RegisterChunkOnWebSocket(loggingChannel chan map[
 				return
 			}
 
-			s.RoutineWaitGroup.Add(2)
+			// Spin up Routines to manage this websocket upgrade request
+			// When this socket is closed all management of this queue is
+			// Stopped leading it to grow to its max capacity and lock up
+			s.routineWaitGroup.Add(2)
 			go s.HandleReceivedSignals(loggingChannel, WebSocketConnection);
 			go s.HandleSignalTransmissions(loggingChannel ,WebSocketConnection, chunkTypeString )
-			s.RoutineWaitGroup.Wait()
+			s.routineWaitGroup.Wait()
 
 	})
 }
 
 func (s *ChunkTypeToChannelMap)HandleReceivedSignals(loggingChannel chan map[zerolog.Level]string, WebSocketConnection *websocket.Conn) {
 
-	defer s.RoutineWaitGroup.Done()
+	defer s.routineWaitGroup.Done()
 	
 	for{
+		// We now just wait for the close message
 		_, _, err := WebSocketConnection.ReadMessage()
 		if err != nil {
 			loggingChannel <- CreateLogMessage(zerolog.WarnLevel, "Issue reading message to WebSocket:"+ err.Error())
@@ -138,14 +159,14 @@ func (s *ChunkTypeToChannelMap)HandleReceivedSignals(loggingChannel chan map[zer
 			break;
 		}
 	}
-
 }
 
 func (s *ChunkTypeToChannelMap)HandleSignalTransmissions(loggingChannel chan map[zerolog.Level]string, WebSocketConnection *websocket.Conn, chunkTypeString string) {
 
-	defer s.RoutineWaitGroup.Done()
+	defer s.routineWaitGroup.Done()
 
 	for {
+		// Now we get the data to transmit on the websocket
 		var dataString, _ = s.GetChannelData(chunkTypeString)
 		err := WebSocketConnection.WriteMessage(websocket.TextMessage, []byte(dataString))
 		if err != nil {
@@ -154,5 +175,4 @@ func (s *ChunkTypeToChannelMap)HandleSignalTransmissions(loggingChannel chan map
 			break
 		}
 	}
-
 }

--- a/Routines/ChunkRouter.go
+++ b/Routines/ChunkRouter.go
@@ -213,7 +213,6 @@ func (s *ChunkTypeToChannelMap)HandleSignalTransmissions(loggingChannel chan map
 		select {
 		case bChannelExists = <-chbCannelExists:
 			strJSONData = <- chstrJSONData
-			loggingChannel <- CreateLogMessage(zerolog.WarnLevel, "1")
 		case <-chTimeout:
 			// And continure if a timeout occurred
 			continue

--- a/Routines/LoggingRoutine.go
+++ b/Routines/LoggingRoutine.go
@@ -7,7 +7,17 @@ import (
 	"github.com/rs/zerolog"
 )
 
-func HandleLogging(configJson map[string]interface{}, routineCompleteChannel chan bool, dataChannel chan map[zerolog.Level]string) {
+type SystemStatistic struct {
+	StatEnvironment string `json:"StatEnvironment"`
+	StatName string `json:"StatName"`
+	StatStaus string `json:"StatStaus"`
+}
+
+type SystemInfo struct {
+	SystemStat SystemStatistic `json:"SystemInfo"`
+}
+
+func HandleLogging(configJson map[string]interface{}, routineCompleteChannel chan bool, incomingDataChannel chan map[zerolog.Level]string) {
 
 	// And finally create a logger
 	var LogLevel = zerolog.DebugLevel
@@ -79,7 +89,7 @@ func HandleLogging(configJson map[string]interface{}, routineCompleteChannel cha
 	logger.Info().Msg("Starting logging routine")
 
 	for {
-		levelMessageMap := <-dataChannel
+		levelMessageMap := <-incomingDataChannel
 
 		for logLevelKey, LogMessageString := range levelMessageMap {
 			if logLevelKey == zerolog.DebugLevel {

--- a/Routines/WSDataTxRoutine.go
+++ b/Routines/WSDataTxRoutine.go
@@ -14,7 +14,7 @@ var upgrader = websocket.Upgrader{
 	WriteBufferSize: 1024,
 }
 
-func HandleWebSocketChunkTransmissions(configJson map[string]interface{}, loggingChannel chan map[zerolog.Level]string, incomingDataChannel <-chan string) {
+func HandleWSDataChunkTx(configJson map[string]interface{}, loggingChannel chan map[zerolog.Level]string, incomingDataChannel <-chan string) {
 
 	// Create websocket variables
 	var port string

--- a/Routines/WSDataTxRoutine.go
+++ b/Routines/WSDataTxRoutine.go
@@ -76,7 +76,7 @@ func RunChunkRoutingRoutine(loggingChannel chan map[zerolog.Level]string, incomi
 			}
 
 			// And checking if it exists and trying to route it
-			chunkTypeRoutingMap.SendChunkToWebSocket(loggingChannel, chunkTypeStringKey, JSONDataString, router)
+			chunkTypeRoutingMap.SendChunkToWebSocket(loggingChannel, chunkTypeStringKey, strJSONData, router)
 		}
 
 		if time.Since(currentTime) > 1000*time.Millisecond {

--- a/Routines/WSDataTxRoutine.go
+++ b/Routines/WSDataTxRoutine.go
@@ -5,25 +5,19 @@ import (
 	"net/http"
 	"os"
 	"github.com/gin-gonic/gin"
-	"github.com/gorilla/websocket"
 	"github.com/rs/zerolog"
 )
 
-var upgrader = websocket.Upgrader{
-	ReadBufferSize:  1024,
-	WriteBufferSize: 1024,
-}
-
 func HandleWSDataChunkTx(configJson map[string]interface{}, loggingChannel chan map[zerolog.Level]string, incomingDataChannel <-chan string) {
-
+	
 	// Create websocket variables
 	var port string
 
 	// And then try parse the JSON string
-	if WebSocketTxConfig, exists := configJson["WebSocketTxConfig"].(map[string]interface{}); exists {
+	if WebSocketTxConfig, exists := configJson["WebSocketDataTxConfig"].(map[string]interface{}); exists {
 		port = WebSocketTxConfig["Port"].(string)
 	} else {
-		loggingChannel <- CreateLogMessage(zerolog.FatalLevel, "WebSocketTxConfig Config not found or not correct")
+		loggingChannel <- CreateLogMessage(zerolog.FatalLevel, "WebSocketDataTxConfig Config not found or not correct")
 		os.Exit(1)
 		return
 	}

--- a/Routines/WSReportingTxRoutine.go
+++ b/Routines/WSReportingTxRoutine.go
@@ -9,7 +9,7 @@ import (
 )
 
 
-func HandleWSReportingTx(configJson map[string]interface{}, routineCompleteChannel chan bool, loggingChannel chan map[zerolog.Level]string, incomingDataChannel <-chan string) {
+func HandleWSReportingTx(configJson map[string]interface{}, routineCompleteChannel chan bool, loggingChannel chan map[zerolog.Level]string, incomingDataChannel chan string) {
 
 	// Create websocket variables
 	var port string
@@ -39,9 +39,9 @@ func HandleWSReportingTx(configJson map[string]interface{}, routineCompleteChann
 
 }
 
-func RunReportingRoutine(loggingChannel chan map[zerolog.Level]string, routineCompleteChannel chan bool, incomingDataChannel <-chan string, router *gin.Engine) {
+func RunReportingRoutine(loggingChannel chan map[zerolog.Level]string, routineCompleteChannel chan bool, incomingDataChannel chan string, router *gin.Engine) {
 
-	chunkTypeRoutingMap := NewChunkTypeToChannelMap(loggingChannel)
+	chunkTypeRoutingMap := NewChunkTypeToChannelMap(loggingChannel, incomingDataChannel)
 
 	for {
 

--- a/Routines/WSReportingTxRoutine.go
+++ b/Routines/WSReportingTxRoutine.go
@@ -1,0 +1,74 @@
+package Routines
+
+import (
+	"encoding/json"
+	"net/http"
+	"os"
+	"github.com/gin-gonic/gin"
+	"github.com/rs/zerolog"
+)
+
+
+func HandleWSReportingTx(configJson map[string]interface{}, routineCompleteChannel chan bool, loggingChannel chan map[zerolog.Level]string, incomingDataChannel <-chan string) {
+
+	// Create websocket variables
+	var port string
+
+	// And then try parse the JSON string
+	if WebSocketTxConfig, exists := configJson["WebSocketReportingTxConfig"].(map[string]interface{}); exists {
+		port = WebSocketTxConfig["Port"].(string)
+	} else {
+		loggingChannel <- CreateLogMessage(zerolog.FatalLevel, "WebSocketReportingTxConfig Config not found or not correct")
+		os.Exit(1)
+		return
+	}
+
+	// Then we run the HTTP router
+	router := gin.Default()
+	// Allow all origins to connect
+	// Note that is is not safe
+	upgrader.CheckOrigin = func(r *http.Request) bool {
+		return true
+	}
+
+	go RunReportingRoutine(loggingChannel, routineCompleteChannel, incomingDataChannel, router)
+	loggingChannel <- CreateLogMessage(zerolog.ErrorLevel, "Starting http router")
+	router.Run(":" + port)
+
+}
+
+func RunReportingRoutine(loggingChannel chan map[zerolog.Level]string, routineCompleteChannel chan bool, incomingDataChannel <-chan string, router *gin.Engine) {
+
+	chunkTypeRoutingMap := new(ChunkTypeToChannelMap)
+
+	for {
+
+		// Unmarshal the JSON string into a map
+		JSONDataString := <-incomingDataChannel
+		var JSONData map[string]interface{}
+
+		if err := json.Unmarshal([]byte(JSONDataString), &JSONData); err != nil {
+			loggingChannel <- CreateLogMessage(zerolog.ErrorLevel, "Error unmarshaling JSON in routing routine:"+err.Error())
+			// loggingChannel <- CreateLogMessage(zerolog.DebugLevel, "Received JSON as follows { "+JSONDataString+" }")
+			// return
+		} else {
+			// Then try forward the JSON data onwards
+			// By first getting the root JSON Key (ChunkType)
+			var chunkTypeStringKey string
+
+			for key := range JSONData {
+				chunkTypeStringKey = key
+				break // We assume there's only one root key
+			}
+
+			// And checking if it exists and trying to route it
+			sentSuccessfully := chunkTypeRoutingMap.SendChunkToWebSocket(loggingChannel, chunkTypeStringKey, JSONDataString, router)
+			if !sentSuccessfully {
+					loggingChannel <- CreateLogMessage(zerolog.WarnLevel, "ChunkType - "+chunkTypeStringKey+" - newly registered in routing map")
+			}
+		}
+	}
+
+	routineCompleteChannel <- true
+}
+

--- a/Routines/WSReportingTxRoutine.go
+++ b/Routines/WSReportingTxRoutine.go
@@ -18,6 +18,7 @@ func HandleWSReportingTx(configJson map[string]interface{}, routineCompleteChann
 	if WebSocketTxConfig, exists := configJson["WebSocketReportingTxConfig"].(map[string]interface{}); exists {
 		port = WebSocketTxConfig["Port"].(string)
 	} else {
+		
 		loggingChannel <- CreateLogMessage(zerolog.FatalLevel, "WebSocketReportingTxConfig Config not found or not correct")
 		os.Exit(1)
 		return
@@ -32,7 +33,7 @@ func HandleWSReportingTx(configJson map[string]interface{}, routineCompleteChann
 	}
 
 	go RunReportingRoutine(loggingChannel, routineCompleteChannel, incomingDataChannel, router)
-	loggingChannel <- CreateLogMessage(zerolog.ErrorLevel, "Starting http router")
+	loggingChannel <- CreateLogMessage(zerolog.InfoLevel, "Starting http router")
 	router.Run(":" + port)
 
 }

--- a/main.go
+++ b/main.go
@@ -45,7 +45,7 @@ func main() {
 	go Routines.HandleTCPReceivals(serverConfigStringMap, LoggingChannel, GenericChunkChannel)
 
 	routineCount = routineCount + 1
-	go Routines.HandleWebSocketChunkTransmissions(serverConfigStringMap, LoggingChannel, GenericChunkChannel)
+	go Routines.HandleWSDataChunkTx(serverConfigStringMap, LoggingChannel, GenericChunkChannel)
 
 	for {
 		time.Sleep(60 * time.Second)

--- a/main.go
+++ b/main.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"os"
 	"time"
-
 	"github.com/Sense-Scape/Go_TCP_Websocket_Adapter/v2/Routines"
 	"github.com/rs/zerolog"
 )

--- a/main.go
+++ b/main.go
@@ -35,10 +35,13 @@ func main() {
 		return
 	}
 
+	routineCount = routineCount + 1
 	LoggingChannel := make(chan map[zerolog.Level]string)
+	go Routines.HandleLogging(serverConfigStringMap, routineCompleteChannel, LoggingChannel)
 
 	routineCount = routineCount + 1
-	go Routines.HandleLogging(serverConfigStringMap, routineCompleteChannel, LoggingChannel)
+	ReportingChannel := make(chan string)
+	go Routines.HandleWSReportingTx(serverConfigStringMap,routineCompleteChannel,LoggingChannel,ReportingChannel)
 
 	routineCount = routineCount + 1
 	GenericChunkChannel := make(chan string)

--- a/main.go
+++ b/main.go
@@ -36,19 +36,20 @@ func main() {
 	}
 
 	routineCount = routineCount + 1
-	LoggingChannel := make(chan map[zerolog.Level]string)
+	LoggingChannel := make(chan map[zerolog.Level]string, 1000)
+
 	go Routines.HandleLogging(serverConfigStringMap, routineCompleteChannel, LoggingChannel)
 
 	routineCount = routineCount + 1
-	ReportingChannel := make(chan string)
+	ReportingChannel := make(chan string, 1000)
 	go Routines.HandleWSReportingTx(serverConfigStringMap,routineCompleteChannel,LoggingChannel,ReportingChannel)
 
 	routineCount = routineCount + 1
-	GenericChunkChannel := make(chan string)
+	GenericChunkChannel := make(chan string, 1000)
 	go Routines.HandleTCPReceivals(serverConfigStringMap, LoggingChannel, GenericChunkChannel)
 
 	routineCount = routineCount + 1
-	go Routines.HandleWSDataChunkTx(serverConfigStringMap, LoggingChannel, GenericChunkChannel)
+	go Routines.HandleWSDataChunkTx(serverConfigStringMap, LoggingChannel, GenericChunkChannel, ReportingChannel)
 
 	for {
 		time.Sleep(60 * time.Second)


### PR DESCRIPTION
Active WeSocket connections will now report how many items are in their queues.
See attached picture for an explanation as to how routines interact. src is also attached
![image](https://github.com/Sense-Scape/TCP_Websocket_Adapter/assets/71123738/1334ec24-dfa0-4896-8f90-05a46707a974)
[AdapterRoutines.zip](https://github.com/user-attachments/files/15751513/AdapterRoutines.zip)
